### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/hpo-web-ci.yml
+++ b/.github/workflows/hpo-web-ci.yml
@@ -9,10 +9,10 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 24.5.0
           cache: 'npm'

--- a/.github/workflows/hpo-web-prod-deploy.yml
+++ b/.github/workflows/hpo-web-prod-deploy.yml
@@ -11,18 +11,18 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Authenticate to Google Cloud
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GCLOUD_SA_KEY }}'
 
     - name: Setup Google Cloud CLI
-      uses: 'google-github-actions/setup-gcloud@v1'
+      uses: 'google-github-actions/setup-gcloud@v2'
 
     - name: Configure Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 24.5.0
         cache: 'npm'

--- a/.github/workflows/hpo-web-sqa-deploy.yml
+++ b/.github/workflows/hpo-web-sqa-deploy.yml
@@ -15,18 +15,18 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Authenticate to Google Cloud
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GCLOUD_SA_KEY }}'
 
     - name: Setup Google Cloud CLI
-      uses: 'google-github-actions/setup-gcloud@v1'
+      uses: 'google-github-actions/setup-gcloud@v2'
 
     - name: Configure Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 24.5.0
         cache: 'npm'


### PR DESCRIPTION
Bump actions/checkout v3→v4, actions/setup-node v3→v4, google-github-actions/auth v1→v2, setup-gcloud v1→v2.